### PR TITLE
Speed up dotReturn

### DIFF
--- a/resources/scripts/index.js
+++ b/resources/scripts/index.js
@@ -359,8 +359,17 @@ function dotReturn(){
         let currentY = parseInt(dotElements[i].style.top, 10);
         let movementX = 0;
         let movementY = 0;
-        let moveSpeedX = 1;
-        let moveSpeedY = 1;
+        let moveSpeedX = 2;
+        let moveSpeedY = 2;
+        let distanceX = Math.abs(currentX - dots[i].left);
+        let distanceY = Math.abs(currentY - dots[i].top);
+
+        if (distanceX <= 10 && distanceY <= 10){
+            dotElements[i].style.left = `${dots[i].left}px`;
+            dotElements[i].style.top = `${dots[i].top}px`;
+            hasReturned[i] = true;
+            continue;
+        }
 
         if (currentX < dots[i].left){
             movementX = moveSpeedX;
@@ -378,17 +387,17 @@ function dotReturn(){
             movementY = 0;
         }
 
-        currentX += movementX;
-        currentY += movementY;
-
-        dotElements[i].style.left = `${currentX}px`;
-        dotElements[i].style.top = `${currentY}px`;
-
         if (currentY === dots[i].top && currentX === dots[i].left){
             hasReturned[i] = true;
         } else {
             hasReturned[i] = false;
         }
+
+        currentX += movementX;
+        currentY += movementY;
+
+        dotElements[i].style.left = `${currentX}px`;
+        dotElements[i].style.top = `${currentY}px`;
     }
 
     for (let i = 0; i < dots.length; i++){


### PR DESCRIPTION
Speeds up dotReturn by setting moveSpeedX and moveSpeedY to '2'. 

Also implements failsafe to ensure that non-'1' moveSpeeds cannot cause an infinite loop by preventing the dot to get reach an exact .top or .left value. For example a dot  with a current value of '3px' trying to reach '2px' with a moveSpeed of '2px' would previously jump to 1px then back to 3px then back to 1px, etc.

Now when the diff between currentX and targetX <= 10 px, it is just set to it's target value.